### PR TITLE
morsecode: Standardize string-levenshtein signature to return Index type

### DIFF
--- a/benchmarks/morsecode/typed/main.rkt
+++ b/benchmarks/morsecode/typed/main.rkt
@@ -14,7 +14,7 @@
   [string->morse (-> String String)])
 
 (require/typed/check "levenshtein.rkt"
-               [string-levenshtein (String String -> Integer)])
+               [string-levenshtein (String String -> Index)])
 
 (define word-frequency-list "./../base/frequency.rktd")
 (define word-frequency-list-small "./../base/frequency-small.rktd")


### PR DESCRIPTION
In `levenshtein.rkt`, the `string-levenshtein` function has the signature `(-> String String Index)`. `main.rkt` should import it under the same signature.